### PR TITLE
#27 : Provide an example of a mos scripting

### DIFF
--- a/scripts/parametersVariations.mos
+++ b/scripts/parametersVariations.mos
@@ -1,0 +1,15 @@
+project_home := ""; // To be adapted! Please keep in mind that even in Windows, you should have the path written in a Linux fashion, using / and not \
+
+loadModel(Modelica);
+loadFile(project_home + "Dynawo/package.mo");
+
+loadFile(project_home + "test_cases/test002_StepQ.mo"); getErrorString();
+setCommandLineOptions("--matchingAlgorithm=PFPlusExt --indexReductionMethod=dynamicStateSelection -d=initialization,NLSanalyticJacobian,newInst -d=initialization"); getErrorString();
+buildModel(test002_StepQ, outputFormat="csv", variableFilter=".*iqCmdPu", stopTime=10); getErrorString();
+
+for i in 0:5 loop
+  value := 0.00001 * (10) ^ (i);
+  system("test002_StepQ.exe -noEventEmit -override=wT4ACurrentSource.tQFilt="+String(value)+" -r=StepQ_tQFilt" + String(i) + "_res.csv");
+end for;
+
+system("del *.o *.c *.log *.h *.exe *.libs *.makefile *.json *.xml *.intdata *.realdata");


### PR DESCRIPTION
It is an example of a mos scripting: this allows to automatically launch a set of cases varying some parameters for example and collect the output files (here as csv).
It can be launched using %OPENMODELICAPATH%/omc/bin parametersVariations.mos (if that doesn't work just type the real directory path), and works for Windows installation once one has filled in the project_path entry at the beginning of the script.

Be careful on the directory you use to launch it as the last line will erase all *.cpp *.h and so on files...

Here is the complete list of instructions you can use in such a script - https://build.openmodelica.org/Documentation/OpenModelica.Scripting.html.